### PR TITLE
Remove support for python2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -29,10 +29,6 @@ Build-Depends: debhelper (>= 9),
                openssl,
                php-all-dev,
                php-cli,
-               python,
-               python-dev,
-               python-passlib,
-               python-setuptools,
                python3,
                python3-dev,
                python3-setuptools
@@ -135,21 +131,6 @@ Depends: libzeroc-ice3.7 (= ${binary:Version}),
 Provides: ${php:Provides}
 Description: PHP extension for Ice
  This package contains a PHP extension for communicating with Ice.
- .
- Ice is a comprehensive RPC framework that helps you network your software
- with minimal effort. Ice takes care of all interactions with low-level
- network programming interfaces and allows you to focus your efforts on
- your application logic.
-
-Package: python-zeroc-ice
-Architecture: any
-Section: python
-Depends: libzeroc-ice3.7 (= ${binary:Version}),
-         ${misc:Depends},
-         ${python:Depends},
-         ${shlibs:Depends}
-Description: Python 2 extension for Ice
- This package contains a Python 2 extension for communication with Ice.
  .
  Ice is a comprehensive RPC framework that helps you network your software
  with minimal effort. Ice takes care of all interactions with low-level

--- a/debian/rules
+++ b/debian/rules
@@ -52,8 +52,6 @@ INSTALL_EXCLUDE		= usr/bin/slice2confluence
 
 PHP_VERSIONS 		:= $(shell /usr/sbin/phpquery -V)
 
-PYTHON_VERSIONS 	:= 2 3
-export PYTHON2DIR 	:= $(shell python2 -c "import sys;print('python{0}.{1}'.format(sys.version_info.major, sys.version_info.minor))")
 export PYTHON3DIR 	:= $(shell python3 -c "import sys;print('python{0}.{1}'.format(sys.version_info.major, sys.version_info.minor))")
 
 export VERSION   := $(shell echo $(DEB_VERSION_UPSTREAM) | sed -e 's,^\([.0-9|.a-z]*\).*,\1,')
@@ -74,7 +72,7 @@ else
 	endif
 endif
 
-DHARGS	= --parallel --with maven_repo_helper --with systemd --with php --with python3 --with python2 --with javahelper
+DHARGS	= --parallel --with maven_repo_helper --with systemd --with php --with python3 --with javahelper
 
 MAKEOPTS = V=1 prefix=/usr DESTDIR=$(DESTDIR)
 
@@ -90,10 +88,7 @@ endif
 	  cp -a php php-$${v}; \
 	  PHP_CONFIG=php-config$${v} $(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) -C php-$${v}; \
 	done
-	for v in $(PYTHON_VERSIONS); do \
-	  cp -a python python-$${v}; \
-	  $(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) PYTHON=python$${v} -C python-$${v}; \
-	done
+	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) PYTHON=python3 -C python;
 
 override_dh_auto_build-indep:
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) -C cpp slice2java
@@ -107,9 +102,7 @@ override_dh_auto_install-arch:
 	for v in $(PHP_VERSIONS); do \
 	  PHP_CONFIG=php-config$${v} $(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) -C php-$${v} install; \
 	done
-	for v in $(PYTHON_VERSIONS); do \
-	  $(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) PYTHON=python$${v} -C python-$${v} install; \
-	done
+	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) PYTHON=python3 -C python install
 	rm -rf $(addprefix $(DESTDIR)/,$(INSTALL_EXCLUDE))
 
 override_dh_auto_install-indep:
@@ -120,9 +113,6 @@ override_dh_auto_clean-arch:
 	$(MAKE) $(MAKEOPTS) OPTIMIZE=$(OPTIMIZE) LANGUAGES=cpp CONFIGS="shared cpp11-shared static cpp11-static" distclean
 	for v in $(PHP_VERSIONS); do \
 	  rm -rf php-$${v}; \
-	done
-	for v in $(PYTHON_VERSIONS); do \
-	  rm -rf python-$${v}; \
 	done
 
 override_dh_auto_clean-indep:
@@ -139,14 +129,14 @@ endif
 
 override_dh_auto_test-arch:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	-python cpp/allTests.py --rfilter=IceUtil/stacktrace --rfilter IceGrid/simple --rfilter IceDiscovery
-	-python cpp/allTests.py --config=cpp11-shared --rfilter=IceUtil/stacktrace --rfilter IceGrid/simple --rfilter IceDiscovery
+	-python3 cpp/allTests.py --rfilter=IceUtil/stacktrace --rfilter IceGrid/simple --rfilter IceDiscovery
+	-python3 cpp/allTests.py --config=cpp11-shared --rfilter=IceUtil/stacktrace --rfilter IceGrid/simple --rfilter IceDiscovery
 endif
 
 override_dh_auto_test-indep:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	-python java/allTests.py --rfilter Glacier2 --rfilter IceGrid --rfilter IceDiscovery
-	-python java-compat/allTests.py --rfilter Glacier2 --rfilter IceGrid --rfilter IceDiscovery
+	-python3 java/allTests.py --rfilter Glacier2 --rfilter IceGrid --rfilter IceDiscovery
+	-python3 java-compat/allTests.py --rfilter Glacier2 --rfilter IceGrid --rfilter IceDiscovery
 endif
 
 override_dh_clean:


### PR DESCRIPTION
Remove python2 packages from the 3.7-next branch, this branch will be used to build the packages for Debian and Ubuntu distributions that already drop python2