### PR TITLE
JDK 21 support: adjust the targetJavaRelease to 8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+zeroc-ice (3.7.10-2) unstable; urgency=medium
+
+  * d/rules: Adjust javac -source/-target using $java_compat_level (Closes: #1057672)
+
+ -- Pushkar Kulkarni <pushkar.kulkarni@canonical.com>  Thu, 15 Feb 2024 21:19:59 +0530
+
 zeroc-ice (3.7.10-1) unstable; urgency=medium
 
   * New upstream version 3.7.10

--- a/debian/patches/java-compat-target-release.patch
+++ b/debian/patches/java-compat-target-release.patch
@@ -1,0 +1,22 @@
+Description: Use the right targetJavaRelease for java-compat
+ While the 'java' module is currently compiled with targetJavaRelease 8, the
+ 'java-compat' module is compiled with targetJavaRelease 7 which is not supported
+ by JDK 21. We can use $(java_compat_level) for 'java-compat'. Note that if we
+ use it for 'java' it results in a build failure if the default-jdk is lower than
+ JDK 21. Hence, the need for this patch.
+Author: Pushkar Kulkarni <pushkar.kulkarni@canonical.com>
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1057672 
+Forwarded: no
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/java-compat/Makefile
++++ b/java-compat/Makefile
+@@ -22,6 +22,8 @@
+   GRADLEARGS += -Dorg.gradle.project.binDir=$(install_bindir)
+ endif
+ 
++GRADLEARGS += -PtargetJavaRelease=$(JAVA_TARGET_RELEASE)
++
+ all:
+ 	$(GRADLE) $(GRADLEARGS) build
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 java-build.patch
+java-compat-target-release.patch

--- a/debian/rules
+++ b/debian/rules
@@ -32,6 +32,9 @@ export OFFLINE_GRADLEARGS	= --offline \
 			  -PiceBuilderClassPath=com.zeroc.gradle.ice-builder
 endif
 
+include /usr/share/java/java_defaults.mk
+export JAVA_TARGET_RELEASE=$(java_compat_level)
+
 export GRADLEARGS	= --gradle-user-home $(CURDIR)/.gradle \
 			  --info \
 			  --console plain \


### PR DESCRIPTION
This is related to JDK 21 support. The targetJavaRelease for java-compat needs to be updated to 8. Ideally, we should've used java-common's $java_compat_level here, but the target release is defined in gradle.properties and interpolation via an environment variable is not feasible.

Fixes: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1057672